### PR TITLE
Fix: reference image markdown when there is not reference.

### DIFF
--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -747,6 +747,20 @@ describe('images', () => {
       </p>
     `)
   })
+
+  it('should handle an image reference with a missing reference', () => {
+    render(
+        compiler(theredoc`
+          ![test][1]
+        `)
+    )
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <span>
+        ![test][1]
+      </span>
+    `)
+  })
 })
 
 describe('links', () => {
@@ -845,6 +859,16 @@ describe('links', () => {
           foo
         </a>
       </p>
+    `)
+  })
+
+  it('should handle a link reference with a missing reference', () => {
+    render(compiler('[foo][1]'))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <span>
+        [foo][1]
+      </span>
     `)
   })
 

--- a/index.tsx
+++ b/index.tsx
@@ -1660,23 +1660,33 @@ export function compiler(
     refImage: {
       _match: simpleInlineRegex(REFERENCE_IMAGE_R),
       _order: Priority.MAX,
-      _parse(capture) {
+      _parse(capture, parse, state) {
         return {
           _alt: capture[1] || undefined,
+          _fallbackContent: parse(
+              capture[0].replace(SQUARE_BRACKETS_R, '\\$1'),
+              state
+          ),
           _ref: capture[2],
         }
       },
       _react(node, output, state) {
-        return (
+        return refs[node._ref] ? (
           <img
             key={state._key}
             alt={node._alt}
             src={sanitizeUrl(refs[node._ref]._target)}
             title={refs[node._ref]._title}
           />
+        ) : (
+            <span key={state._key}>{ output(node._fallbackContent, state) }</span>
         )
       },
-    } as MarkdownToJSX.Rule<{ _alt?: string; _ref: string }>,
+    } as MarkdownToJSX.Rule<{
+      _alt?: string
+      _fallbackContent: MarkdownToJSX.ParserResult
+      _ref: string
+    }>,
 
     refLink: {
       _match: inlineRegex(REFERENCE_LINK_R),


### PR DESCRIPTION
My attempt at fixing #524. This adds a fallback for when an image reference markdown is missing it's reference. As with links, the markdown is displayed.

This also adds two tests for this scenario, for images and links.