### PR TITLE
fix: consecutive blockquotes blocks

### DIFF
--- a/.changeset/strange-planets-buy.md
+++ b/.changeset/strange-planets-buy.md
@@ -2,4 +2,27 @@
 "markdown-to-jsx": patch
 ---
 
-fix: consecutive blockquotes blocks
+fix: double newline between consecutive blockquote syntax creates separate blockquotes
+
+Previously, for consecutive blockquotes they were rendered as one:
+
+**Input**
+ 
+```md
+> Block A.1
+> Block A.2
+
+> Block B.1
+```
+
+**Output**
+
+```html
+<blockquote>
+  <p>Block A.1</p>
+  <p>Block A.2</p>
+  <p>Block.B.1</p>
+</blockquote>
+```
+
+This is not compliant with the [GFM spec](https://github.github.com/gfm/#block-quotes) which states that consecutive blocks should be created if there is a blank line between them.

--- a/.changeset/strange-planets-buy.md
+++ b/.changeset/strange-planets-buy.md
@@ -1,0 +1,5 @@
+---
+"markdown-to-jsx": patch
+---
+
+fix: consecutive blockquotes blocks

--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -563,6 +563,39 @@ describe('misc block level elements', () => {
       </blockquote>
     `)
   })
+
+  it('should handle lazy continuation lines of blockquotes', () => {
+    render(compiler('> Line 1\nLine 2\n>Line 3'))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <blockquote>
+        <p>
+          Line 1
+      Line 2
+      Line 3
+        </p>
+      </blockquote>
+    `)
+  })
+
+  it('should handle consecutive blockquotes', () => {
+    render(compiler('> Something important, perhaps?\n\n> Something else'))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <div>
+        <blockquote>
+          <p>
+            Something important, perhaps?
+          </p>
+        </blockquote>
+        <blockquote>
+          <p>
+            Something else
+          </p>
+        </blockquote>
+      </div>
+    `)
+  })
 })
 
 describe('headings', () => {

--- a/index.tsx
+++ b/index.tsx
@@ -177,7 +177,7 @@ const ATTR_EXTRACTOR_R =
 
 const AUTOLINK_MAILTO_CHECK_R = /mailto:/i
 const BLOCK_END_R = /\n{2,}$/
-const BLOCKQUOTE_R = /^( *>[^\n]+(\n[^\n]+)*\n*)+\n{2,}/
+const BLOCKQUOTE_R = /^(\s*>[\s\S]*?)(?=\n{2,})/
 const BLOCKQUOTE_TRIM_LEFT_MULTILINE_R = /^ *> ?/gm
 const BREAK_LINE_R = /^ {2,}\n/
 const BREAK_THEMATIC_R = /^(?:( *[-*_])){3,} *(?:\n *)+\n/


### PR DESCRIPTION
Currently, if we have consecutive blockquotes, they are rendered as one:

**Input**
 
```md
> Block A.1
> Block A.2

> Block B.1
```

**Output**

```html
<blockquote>
  <p>Block A.1</p>
  <p>Block A.2</p>
  <p>Block.B.1</p>
</blockquote>
```

This is not compliant with the [GFM spec](https://github.github.com/gfm/#block-quotes) which states that we should create consecutive blocks if there is a blank line between them

---

This PR solves that by tweaking the `BLOCKQUOTE_R` regex and adding relevant tests. Basically, we use a lookahead to match everything until we hit at least two `\n`.