### PR TITLE
fix: handle render of empty noInnerParse html nodes like script and style tag #597

### DIFF
--- a/.changeset/sharp-lobsters-turn.md
+++ b/.changeset/sharp-lobsters-turn.md
@@ -1,0 +1,5 @@
+---
+"markdown-to-jsx": patch
+---
+
+fix: handle empty HTML tags more consistently #597

--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -4684,3 +4684,12 @@ it('handles naked brackets in link text', () => {
     </a>
   `)
 })
+
+it('#597 handles script tag with empty content', () => {
+  render(compiler('<script src="dummy.js"></script>'))
+
+  expect(root.innerHTML).toMatchInlineSnapshot(`
+    <script src="dummy.js">
+    </script>
+  `)
+})

--- a/index.tsx
+++ b/index.tsx
@@ -1538,7 +1538,7 @@ export function compiler(
       render(node, output, state) {
         return (
           <node.tag key={state.key} {...node.attrs}>
-            {node.text || output(node.children, state)}
+            {node.text || (node.children ? output(node.children, state) : '')}
           </node.tag>
         )
       },


### PR DESCRIPTION
closes #597
closes #582
Issue was due to script and style tags (elements contained in DO_NOT_PROCESS_HTML_ELEMENTS list) which produces undefined children when parsed. So when text is empty render function will try to render with undefined children which will throw the error.