### PR TITLE
Do not expect ending tag for <br> tag

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -625,7 +625,7 @@ function parseTableRow(
   let tableRow = source
     .trim()
     // isolate situations where a pipe should be ignored (inline code, HTML)
-    .split(/( *(?:`[^`]*`|<.*?>.*?<\/.*?>(?!<\/.*?>)|\\\||\|) *)/)
+    .split(/( *(?:`[^`]*`|<br\/?>|<.*?>.*?<\/.*?>(?!<\/.*?>)|\\\||\|) *)/)
     .reduce((nodes, fragment) => {
       if (fragment.trim() === '|')
         nodes.push(


### PR DESCRIPTION
Every time we have a `<br>` element, the regex expects an ending tag and escapes every `|` character

Example problem:
```markdown
| col1 | col2 | col3 |
|------|-----------------|------------------|
| col1 | <custom-element>col2</custom-element><br> col2 | <custom-element>col3</custom-element><br>col3 |
```
In this example, it interprets the end of the first `<br>` as the end tag of the second `custom-element` causing to escape the `|` character.