### PR TITLE
Fixes catastrophic backtracking for long strings of spaces

### DIFF
--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -4824,3 +4824,25 @@ it('#597 handles script tag with empty content', () => {
     </script>
   `)
 })
+
+it('#473 handles content with multiple empty spaces without crashing', () => {
+  render(
+    compiler(
+      '##Long \r\n                                                                                    \r\n ###input \ntest'
+    )
+  )
+
+  expect(root.innerHTML).toMatchInlineSnapshot(`
+    <div>
+      <h2 id="long">
+        Long
+      </h2>
+      <h3 id="input">
+        input
+      </h3>
+      <p>
+        test
+      </p>
+    </div>
+  `)
+})

--- a/index.tsx
+++ b/index.tsx
@@ -185,7 +185,7 @@ const BREAK_LINE_R = /^ {2,}\n/
 const BREAK_THEMATIC_R = /^(?:( *[-*_])){3,} *(?:\n *)+\n/
 const CODE_BLOCK_FENCED_R =
   /^(?: {1,3})?(`{3,}|~{3,}) *(\S+)? *([^\n]*?)?\n([\s\S]*?)(?:\1\n?|$)/
-const CODE_BLOCK_R = /^(?: {4}[^\n]+\n*)+(?:\n *)+\n?/
+const CODE_BLOCK_R = /^(?: {4}[^\n]+\n*)+(?:\n *)*\n?/
 const CODE_INLINE_R = /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/
 const CONSECUTIVE_NEWLINE_R = /^(?:\n *)*\n/
 const CR_NEWLINE_R = /\r\n?/g


### PR DESCRIPTION
Solves #473 

With a very long input of spaces and the current `CODE_BLOCK_R ` regex, the number of possible combinations becomes huge, causing the regex engine to take an extremely long time to test the input. This small change reduces the backtracking and prevents catastrophic backtracking when faced with a long string of spaces.

Tester for catastrophic backtracing: https://regex101.com/r/85LH2r/1