### PR TITLE
Set compiler return type to React.JSX.Element

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1180,7 +1180,7 @@ function getTag(tag: string, overrides: MarkdownToJSX.Overrides) {
 export function compiler(
   markdown: string = '',
   options: MarkdownToJSX.Options = {}
-) {
+): React.JSX.Element {
   options.overrides = options.overrides || {}
   options.sanitizer = options.sanitizer || sanitizer
   options.slugify = options.slugify || slugify


### PR DESCRIPTION
Without explicitly setting the return type and using React 17 types, TS infers JSX.Element instead of React.JSX.Element. Setting it explicitly ensures the return type is React.JSX.Element.