### PR TITLE
Adding target="_blank" on anchor tags

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1189,6 +1189,7 @@ export function compiler(
     : namedCodesToUnicode
 
   options.createElement = options.createElement || React.createElement
+  options.targetBlank = options.targetBlank || false
 
   // JSX custom pragma
   // eslint-disable-next-line no-unused-vars
@@ -1681,6 +1682,7 @@ export function compiler(
             key={state.key}
             href={options.sanitizer(node.target, 'a', 'href')}
             title={node.title}
+            target={options.targetBlank ? '_blank' : undefined}
           >
             {output(node.children, state)}
           </a>
@@ -2480,6 +2482,11 @@ export namespace MarkdownToJSX {
       tag: HTMLTags,
       attribute: string
     ) => string | null
+
+    /**
+     * allow links to open in a new tab
+     */
+    targetBlank: boolean
 
     /**
      * Override normalization of non-URI-safe characters for use in generating


### PR DESCRIPTION
First, thanks for your time on this project. It is the best markdown converter for React in my opinion due to its light weight.

I am not familiar with open source contributing and yarn, hopefully the PR still conveys the (simple) idea and code changes, even though contributing guidelines are not fully met.

The change allows for the ability to add the target="_blank" on anchor tags, and have them open in a new tag upon click. This makes the links a lot more usable in certain contexts, notably AI generated markdown with links.