### PR TITLE
improve text processing chunking strategy & atx headline selectivity when detecting block syntax

### DIFF
--- a/.changeset/dirty-lies-pump.md
+++ b/.changeset/dirty-lies-pump.md
@@ -1,0 +1,7 @@
+---
+'markdown-to-jsx': patch
+---
+
+Handle spaces in text as a stop token to improve processing, also adapt paragraph detection to exclude non-atx compliant headings if that option is enabled.
+
+Fixes #680

--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -1547,6 +1547,19 @@ describe('links', () => {
       </strong>
     `)
   })
+
+  it('renders plain links preceded by text', () => {
+    render(compiler('Some text http://www.test.com/some-resource/123'))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <span>
+        Some text
+        <a href="http://www.test.com/some-resource/123">
+          http://www.test.com/some-resource/123
+        </a>
+      </span>
+    `)
+  })
 })
 
 describe('lists', () => {

--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -643,9 +643,9 @@ describe('headings', () => {
     render(compiler('#Hello World', { enforceAtxHeadings: true }))
 
     expect(root.innerHTML).toMatchInlineSnapshot(`
-      <span>
+      <p>
         #Hello World
-      </span>
+      </p>
     `)
   })
 

--- a/index.tsx
+++ b/index.tsx
@@ -334,7 +334,7 @@ const TEXT_UNESCAPE_R = /\\([^0-9A-Za-z\s])/g
  * Always take the first character, then eagerly take text until a double space
  * (potential line break) or some markdown-like punctuation is reached.
  */
-const TEXT_PLAIN_R = /^([\s\S](?:(?!  |[0-9]\.)[^=*_~\-\n<`\\\[!])*)/
+const TEXT_PLAIN_R = /^(?: |[\s\S](?:(?!  |[0-9]\.)[^=*_~\-\n<`\\\[! ])*)/
 
 const TRIM_STARTING_NEWLINES = /^\n+/
 
@@ -346,7 +346,6 @@ type LIST_TYPE = 1 | 2
 const ORDERED: LIST_TYPE = 1
 const UNORDERED: LIST_TYPE = 2
 
-const LIST_ITEM_END_R = / *\n+$/
 const LIST_LOOKBEHIND_R = /(?:^|\n)( *)$/
 
 // recognize a `*` `-`, `+`, `1.`, `2.`... list bullet

--- a/index.tsx
+++ b/index.tsx
@@ -1251,7 +1251,6 @@ export function compiler(
 
     const captured = trimEnd(match)
     if (captured == '') {
-      console.log('no')
       return null
     }
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "jest-serializer-html": "^7.1.0",
     "jest-watch-typeahead": "^2.2.2",
     "markdown-it": "^14.0.0",
-    "markdown-to-jsx-latest": "npm:markdown-to-jsx@latest",
+    "markdown-to-jsx-latest": "npm:markdown-to-jsx@7.7.6",
     "microbundle": "^0.15.1",
     "microtime": "^3.1.1",
     "mkdirp": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7114,16 +7114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-to-jsx-latest@npm:markdown-to-jsx@latest":
-  version: 7.7.3
-  resolution: "markdown-to-jsx@npm:7.7.3"
-  peerDependencies:
-    react: ">= 0.14.0"
-  checksum: 10/b71383b98e6254bda2c94ffb0744619c1d89714cdff449defb330e18942c565fc2203d9ba0235aff7bb65a52656b850e4e42d62c65582e500a6b11bd78c6f04b
-  languageName: node
-  linkType: hard
-
-"markdown-to-jsx@workspace:.":
+"markdown-to-jsx-latest@npm:markdown-to-jsx@7.7.6, markdown-to-jsx@workspace:.":
   version: 0.0.0-use.local
   resolution: "markdown-to-jsx@workspace:."
   dependencies:
@@ -7145,7 +7136,7 @@ __metadata:
     jest-serializer-html: "npm:^7.1.0"
     jest-watch-typeahead: "npm:^2.2.2"
     markdown-it: "npm:^14.0.0"
-    markdown-to-jsx-latest: "npm:markdown-to-jsx@latest"
+    markdown-to-jsx-latest: "npm:markdown-to-jsx@7.7.6"
     microbundle: "npm:^0.15.1"
     microtime: "npm:^3.1.1"
     mkdirp: "npm:^3.0.1"


### PR DESCRIPTION
Handle spaces in text as a stop token to improve processing, also adapt paragraph detection to exclude non-atx compliant headings if that option is enabled.

Fixes #680