### PR TITLE
handle escaped characters in more scenarios

### DIFF
--- a/.changeset/cuddly-boxes-bake.md
+++ b/.changeset/cuddly-boxes-bake.md
@@ -1,0 +1,5 @@
+---
+'markdown-to-jsx': patch
+---
+
+Unescape content intended for JSX attributes.

--- a/index.compiler.spec.tsx
+++ b/index.compiler.spec.tsx
@@ -829,6 +829,16 @@ describe('images', () => {
     `)
   })
 
+  it('should handle an image with escaped alt text', () => {
+    render(compiler('![\\-\\<stuff](https://somewhere)'))
+
+    expect(root.innerHTML).toMatchInlineSnapshot(`
+      <img alt="-<stuff"
+           src="https://somewhere"
+      >
+    `)
+  })
+
   it('should handle an image with title', () => {
     render(compiler('![test](/xyz.png "foo")'))
 


### PR DESCRIPTION
fixes #688

This pull request introduces changes to improve how escaped content is handled in JSX attributes and other text processing scenarios. The main focus is on unescaping content consistently across various functions and regular expressions, ensuring proper rendering and sanitization. Additionally, a new test case has been added to verify the handling of escaped alt text in images.

### Improvements to unescaping content:

* [`index.tsx`](diffhunk://#diff-b211563a379985cf25e1ffc4e40fd9bcbb669c8d4c61f4088b32fcd351c2722bL331-R331): Replaced `TEXT_UNESCAPE_R` with `UNESCAPE_R` for consistency and renamed the `unescapeUrl` function to `unescape`. Updated multiple parsing and sanitization functions to use the new `unescape` function for handling escaped content. [[1]](diffhunk://#diff-b211563a379985cf25e1ffc4e40fd9bcbb669c8d4c61f4088b32fcd351c2722bL331-R331) [[2]](diffhunk://#diff-b211563a379985cf25e1ffc4e40fd9bcbb669c8d4c61f4088b32fcd351c2722bL835-R836) [[3]](diffhunk://#diff-b211563a379985cf25e1ffc4e40fd9bcbb669c8d4c61f4088b32fcd351c2722bL1034-R1033) [[4]](diffhunk://#diff-b211563a379985cf25e1ffc4e40fd9bcbb669c8d4c61f4088b32fcd351c2722bL1482-R1480) [[5]](diffhunk://#diff-b211563a379985cf25e1ffc4e40fd9bcbb669c8d4c61f4088b32fcd351c2722bL1528-R1523) [[6]](diffhunk://#diff-b211563a379985cf25e1ffc4e40fd9bcbb669c8d4c61f4088b32fcd351c2722bL1728-R1725) [[7]](diffhunk://#diff-b211563a379985cf25e1ffc4e40fd9bcbb669c8d4c61f4088b32fcd351c2722bL1756-R1752) [[8]](diffhunk://#diff-b211563a379985cf25e1ffc4e40fd9bcbb669c8d4c61f4088b32fcd351c2722bL1889-R1884)

### Testing enhancements:

* [`index.compiler.spec.tsx`](diffhunk://#diff-320fe89774b9058fadbd2bc7759372fa347a4a8837b2fa8794aed30dd43d85d8R832-R841): Added a new test case to verify the handling of images with escaped alt text, ensuring proper rendering of the unescaped content.

### Documentation updates:

* [`.changeset/cuddly-boxes-bake.md`](diffhunk://#diff-83d9475d63b130eef766bfe1ba286641ea8ea2c6ad345a092d7a9f443dc2d63dR1-R5): Documented the patch for unescaping content intended for JSX attributes.