### PR TITLE
refactor(types): pass types for "reactFor"

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1300,7 +1300,7 @@ export function compiler(
     )
   }
 
-  function compile(input: string): React.JSX.Element | React.ReactNode[] {
+  function compile(input: string): React.JSX.Element {
     input = input.replace(FRONT_MATTER_R, '')
 
     let inline = false
@@ -1334,7 +1334,7 @@ export function compiler(
     }
 
     if (options.wrapper === null) {
-      return arr
+      return arr as unknown as React.JSX.Element
     }
 
     const wrapper = options.wrapper || (inline ? 'span' : 'div')

--- a/index.tsx
+++ b/index.tsx
@@ -1119,7 +1119,7 @@ function reactFor(render: ReturnType<typeof createRenderer>) {
   return function patchedRender(
     ast: MarkdownToJSX.ParserResult | MarkdownToJSX.ParserResult[],
     state: MarkdownToJSX.State = {}
-  ): React.ReactNode[] | React.ReactNode {
+  ): React.ReactNode[] {
     if (Array.isArray(ast)) {
       const oldKey = state.key
       const result = []
@@ -1152,7 +1152,7 @@ function reactFor(render: ReturnType<typeof createRenderer>) {
       ast,
       patchedRender as unknown as MarkdownToJSX.RuleOutput,
       state
-    )
+    ) as React.ReactNode[]
   }
 }
 
@@ -1300,7 +1300,7 @@ export function compiler(
     )
   }
 
-  function compile(input: string): React.JSX.Element {
+  function compile(input: string): React.JSX.Element | React.ReactNode[] {
     input = input.replace(FRONT_MATTER_R, '')
 
     let inline = false
@@ -1328,7 +1328,7 @@ export function compiler(
 
     while (
       typeof arr[arr.length - 1] === 'string' &&
-      !arr[arr.length - 1].trim()
+      !(arr[arr.length - 1] as string).trim()
     ) {
       arr.pop()
     }

--- a/index.tsx
+++ b/index.tsx
@@ -1115,11 +1115,11 @@ function renderNothing() {
   return null
 }
 
-function reactFor(render) {
+function reactFor(render: ReturnType<typeof createRenderer>) {
   return function patchedRender(
     ast: MarkdownToJSX.ParserResult | MarkdownToJSX.ParserResult[],
     state: MarkdownToJSX.State = {}
-  ): React.ReactNode[] {
+  ): React.ReactNode[] | React.ReactNode {
     if (Array.isArray(ast)) {
       const oldKey = state.key
       const result = []
@@ -1148,7 +1148,11 @@ function reactFor(render) {
       return result
     }
 
-    return render(ast, patchedRender, state)
+    return render(
+      ast,
+      patchedRender as unknown as MarkdownToJSX.RuleOutput,
+      state
+    )
   }
 }
 
@@ -1158,10 +1162,12 @@ function createRenderer(
 ) {
   return function renderRule(
     ast: MarkdownToJSX.ParserResult,
-    render: MarkdownToJSX.RuleOutput,
-    state: MarkdownToJSX.State
+    render?: MarkdownToJSX.RuleOutput,
+    state?: MarkdownToJSX.State
   ): React.ReactNode {
-    const renderer = rules[ast.type]._render as MarkdownToJSX.Rule['_render']
+    const renderer = rules[ast.type]._render as NonNullable<
+      MarkdownToJSX.Rule['_render']
+    >
 
     return userRender
       ? userRender(() => renderer(ast, render, state), ast, render, state)
@@ -1169,7 +1175,7 @@ function createRenderer(
   }
 }
 
-function cx(...args) {
+function cx(...args: string[]) {
   return args.filter(Boolean).join(' ')
 }
 
@@ -2127,7 +2133,7 @@ export function compiler(
   }
 
   const parser = parserFor(rules)
-  const emitter: Function = reactFor(createRenderer(rules, options.renderRule))
+  const emitter = reactFor(createRenderer(rules, options.renderRule))
 
   const jsx = compile(markdown)
 


### PR DESCRIPTION
I'm not entirely sure what this function is, maybe emitter is a rename of a function that used to be called react?

I was writing what could possibly be a fork (not sure yet) and want to verify I understand the types correctly.

If this is useful, i might find time to resolve the other errors that show up in strict mode too.