### PR TITLE
fix: angle autolinks with raw HTML disabled

### DIFF
--- a/.changeset/restore-angle-autolinks.md
+++ b/.changeset/restore-angle-autolinks.md
@@ -1,0 +1,5 @@
+---
+'markdown-to-jsx': patch
+---
+
+Restore angle-bracket autolinks when raw HTML parsing is disabled so `<https://...>` still renders as links

--- a/.changeset/tighter-autolinks.md
+++ b/.changeset/tighter-autolinks.md
@@ -1,0 +1,5 @@
+---
+'markdown-to-jsx': patch
+---
+
+Improve autolink parsing: stricter angle controls, domain underscore validation, and added coverage for mailto labels and raw-HTML-disabled cases.


### PR DESCRIPTION
Closes #749 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores angle-bracket autolinks when raw HTML parsing is disabled and tightens autolink parsing (mailto labels, domain underscore validation, and stricter angle content), with corresponding tests.
> 
> - **Parser**:
>   - Restore parsing of angle-bracket autolinks even when `disableParsingRawHTML` is true by attempting angle links before HTML.
>   - Stricter angle autolinks: reject spaces/tabs/newlines/control chars inside `<...>`; preserve `mailto:` labels; handle email-like content without schemes.
>   - Bare URL validation: disallow underscores in the final two domain segments; allow underscores elsewhere.
> - **Tests**:
>   - Add unit and React tests for mailto label preservation, raw-HTML-disabled behavior, angle links with newlines/tabs rejection, invalid domain underscores, and allowed underscore positions.
>   - Ensure default options provide a `slugify` function in tests.
> - **Behavior toggles**:
>   - Respect `disableAutoLink` alongside `disableParsingRawHTML` for bare URLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c48f1562b33aa5b238bba51219a6664a4d4f89c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->