### PR TITLE
fix: initialize _store on raw elements for React dev-mode compatibility

### DIFF
--- a/.changeset/fix-raw-element-store.md
+++ b/.changeset/fix-raw-element-store.md
@@ -1,0 +1,9 @@
+---
+"markdown-to-jsx": patch
+---
+
+Fix "Cannot set properties of undefined (setting 'validated')" error introduced in 9.7.1. React's dev-mode reconciler sets `element._store.validated` to track element creation source; raw elements created by the fast path now include `_store: {}` in non-production builds.
+
+修复 9.7.1 引入的 "Cannot set properties of undefined (setting 'validated')" 错误。React 开发模式协调器设置 `element._store.validated` 来追踪元素创建来源；快速路径创建的原始元素现在在非生产构建中包含 `_store: {}`。
+
+9.7.1 में पेश हुई "Cannot set properties of undefined (setting 'validated')" त्रुटि ठीक की गई। React के dev-mode reconciler द्वारा `element._store.validated` सेट करने के लिए, फास्ट पाथ से बनाए गए raw elements अब non-production builds में `_store: {}` शामिल करते हैं।

--- a/lib/src/index.cjs.spec.tsx
+++ b/lib/src/index.cjs.spec.tsx
@@ -29,6 +29,7 @@ describe('index.cjs.tsx exports', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "$$typeof": Symbol(react.transitional.element),
+        "_store": {},
         "key": "0",
         "props": {
           "children": [

--- a/lib/src/index.spec.tsx
+++ b/lib/src/index.spec.tsx
@@ -29,6 +29,7 @@ describe('index.tsx exports', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "$$typeof": Symbol(react.transitional.element),
+        "_store": {},
         "key": "0",
         "props": {
           "children": [

--- a/lib/src/react.spec.tsx
+++ b/lib/src/react.spec.tsx
@@ -46,6 +46,15 @@ it('should handle a basic string', () => {
   expect(root.innerHTML).toBe('Hello.')
 })
 
+it('raw elements have _store for React dev-mode validation (issue #821)', () => {
+  // React's dev-mode reconciler sets element._store.validated to track whether
+  // elements were created via JSX vs createElement. Without _store this throws
+  // "Cannot set properties of undefined (setting 'validated')".
+  expect(() => render(compiler('# Title\n\nParagraph\n\n- item 1\n- item 2'))).not.toThrow()
+  expect(root.innerHTML).toContain('Title')
+  expect(root.innerHTML).toContain('Paragraph')
+})
+
 it('wraps multiple block element returns in a div to avoid invalid nesting errors', () => {
   render(compiler('# Boop\n\n## Blep'))
 
@@ -1451,6 +1460,7 @@ describe('arbitrary HTML', () => {
     expect(ast).toMatchInlineSnapshot(`
       {
         "$$typeof": Symbol(react.transitional.element),
+        "_store": {},
         "key": "0",
         "props": {
           "children": [
@@ -2601,6 +2611,7 @@ describe('options.wrapper', () => {
       [
         {
           "$$typeof": Symbol(react.transitional.element),
+          "_store": {},
           "key": "0",
           "props": {
             "children": [
@@ -2612,6 +2623,7 @@ describe('options.wrapper', () => {
         },
         {
           "$$typeof": Symbol(react.transitional.element),
+          "_store": {},
           "key": "1",
           "props": {
             "children": [

--- a/lib/src/react.tsx
+++ b/lib/src/react.tsx
@@ -37,13 +37,20 @@ function createRawElement(
   props: any,
   key: any
 ): any {
-  return {
+  var el: any = {
     $$typeof: REACT_ELEMENT_TYPE,
     type: type,
     key: key != null ? '' + key : null,
     ref: null,
     props: props,
   }
+  if (process.env.NODE_ENV !== 'production') {
+    // React's dev-mode reconciler sets element._store.validated to track
+    // whether elements were created via JSX vs createElement. Without _store,
+    // this throws "Cannot set properties of undefined (setting 'validated')".
+    el._store = {}
+  }
+  return el
 }
 
 /**


### PR DESCRIPTION
React's dev-mode reconciler sets element._store.validated to track element provenance. Without _store, this threw "Cannot set properties of undefined (setting 'validated')" for all elements created by the fast path introduced in 9.7.1.

Fixes #821 