### PR TITLE
fix: stop fast-skip from truncating bare email local-parts containing inline-special chars

### DIFF
--- a/.changeset/polite-wasps-brake.md
+++ b/.changeset/polite-wasps-brake.md
@@ -1,0 +1,5 @@
+---
+"markdown-to-jsx": patch
+---
+
+fix: stop fast-skip from truncating bare email local-parts containing inline-special chars

--- a/lib/src/parse.spec.ts
+++ b/lib/src/parse.spec.ts
@@ -425,27 +425,30 @@ describe('parseMarkdown', () => {
   })
 
   it('correctly autolinks bare email whose local-part contains w or f before the @ far from parse start', () => {
-    const state = createInlineState()
     const options = { ...createDefaultOptions(), sanitizer: (x: string) => x }
-    // 'w': local-part starts with plain chars then 'w' which is in INLINE_SPECIAL
+    // 'w': @ at position 68 (prefix=50 + local-part=18), which is > 65, so the fast-skip path fires.
+    // Without the fix the loop lands on the 'h' inside "technicalsupworker" and links only
+    // "hnicalsupworker@example.com", leaving "technicalsup" as plain text.
     const inputW =
-      'Please contact Support at 1-111-111-1111 or email techsupworker@example.com for further assistance.'
-    const resultW = p.parseMarkdown(inputW, state, options) as MarkdownToJSX.ASTNode[]
+      'Please contact Support at 1-111-111-1111 or email technicalsupworker@example.com for further assistance.'
+    const resultW = p.parseMarkdown(inputW, createInlineState(), options) as MarkdownToJSX.ASTNode[]
     expect(resultW[1]).toEqual({
       type: RuleType.link,
-      target: 'mailto:techsupworker@example.com',
+      target: 'mailto:technicalsupworker@example.com',
       title: undefined,
-      children: [{ type: RuleType.text, text: 'techsupworker@example.com' }],
+      children: [{ type: RuleType.text, text: 'technicalsupworker@example.com' }],
     } as MarkdownToJSX.ASTNode)
-    // 'f': local-part starts with plain chars then 'f' which is in INLINE_SPECIAL
+    // 'f': @ at position 66 (prefix=50 + local-part=16), which is > 65, so the fast-skip path fires.
+    // Without the fix the loop lands on the 'h' inside "technicalsupfool" and links only
+    // "hnicalsupfool@example.com", leaving "technicalsup" as plain text.
     const inputF =
-      'Please contact Support at 1-111-111-1111 or email techsupfoo@example.com for further assistance.'
-    const resultF = p.parseMarkdown(inputF, state, options) as MarkdownToJSX.ASTNode[]
+      'Please contact Support at 1-111-111-1111 or email technicalsupfool@example.com for further assistance.'
+    const resultF = p.parseMarkdown(inputF, createInlineState(), options) as MarkdownToJSX.ASTNode[]
     expect(resultF[1]).toEqual({
       type: RuleType.link,
-      target: 'mailto:techsupfoo@example.com',
+      target: 'mailto:technicalsupfool@example.com',
       title: undefined,
-      children: [{ type: RuleType.text, text: 'techsupfoo@example.com' }],
+      children: [{ type: RuleType.text, text: 'technicalsupfool@example.com' }],
     } as MarkdownToJSX.ASTNode)
   })
 

--- a/lib/src/parse.spec.ts
+++ b/lib/src/parse.spec.ts
@@ -398,7 +398,76 @@ describe('parseMarkdown', () => {
     expect((result[1] as MarkdownToJSX.TextNode).text).toBe('**')
   })
 
-  it('rejects angle autolinks containing tabs', () => {
+  it('correctly autolinks bare email whose local-part starts before an INLINE_SPECIAL char, when @ is far from parse start (issue #877)', () => {
+    // The fast-skip optimisation uses INLINE_SPECIAL (which includes 'h', 'w', 'f' for URL
+    // detection) to jump to the next interesting character.  When the @ is more than 64 chars
+    // from the beginning of the parsed string the outer guard disables the email check and the
+    // inner loop can leap over the start of the email's local-part, landing on the 'h' inside
+    // e.g. "technicalsupport" and producing "tec" + link("hnicalsupport@example.com") instead
+    // of the correct link("technicalsupport@example.com").
+    const state = createInlineState()
+    const options = { ...createDefaultOptions(), sanitizer: (x: string) => x }
+    // The long prefix places the @ sign > 64 characters from the start of the string,
+    // triggering the fast-skip path that previously caused the truncation.
+    const input =
+      'Please contact Support at 1-111-111-1111 or email technicalsupport@example.com for further assistance.'
+    const result = p.parseMarkdown(input, state, options) as MarkdownToJSX.ASTNode[]
+    expect(result).toEqual([
+      { type: RuleType.text, text: 'Please contact Support at 1-111-111-1111 or email ' },
+      {
+        type: RuleType.link,
+        target: 'mailto:technicalsupport@example.com',
+        title: undefined,
+        children: [{ type: RuleType.text, text: 'technicalsupport@example.com' }],
+      } as MarkdownToJSX.ASTNode,
+      { type: RuleType.text, text: ' for further assistance.' },
+    ])
+  })
+
+  it('correctly autolinks bare email whose local-part contains w or f before the @ far from parse start', () => {
+    const state = createInlineState()
+    const options = { ...createDefaultOptions(), sanitizer: (x: string) => x }
+    // 'w': local-part starts with plain chars then 'w' which is in INLINE_SPECIAL
+    const inputW =
+      'Please contact Support at 1-111-111-1111 or email techsupworker@example.com for further assistance.'
+    const resultW = p.parseMarkdown(inputW, state, options) as MarkdownToJSX.ASTNode[]
+    expect(resultW[1]).toEqual({
+      type: RuleType.link,
+      target: 'mailto:techsupworker@example.com',
+      title: undefined,
+      children: [{ type: RuleType.text, text: 'techsupworker@example.com' }],
+    } as MarkdownToJSX.ASTNode)
+    // 'f': local-part starts with plain chars then 'f' which is in INLINE_SPECIAL
+    const inputF =
+      'Please contact Support at 1-111-111-1111 or email techsupfoo@example.com for further assistance.'
+    const resultF = p.parseMarkdown(inputF, state, options) as MarkdownToJSX.ASTNode[]
+    expect(resultF[1]).toEqual({
+      type: RuleType.link,
+      target: 'mailto:techsupfoo@example.com',
+      title: undefined,
+      children: [{ type: RuleType.text, text: 'techsupfoo@example.com' }],
+    } as MarkdownToJSX.ASTNode)
+  })
+
+  it('still autolinks bare email at the very start of the string (no fast-skip involved)', () => {
+    const state = createInlineState()
+    const options = { ...createDefaultOptions(), sanitizer: (x: string) => x }
+    const result = p.parseMarkdown(
+      'technicalsupport@example.com',
+      state,
+      options
+    ) as MarkdownToJSX.ASTNode[]
+    expect(result).toEqual([
+      {
+        type: RuleType.link,
+        target: 'mailto:technicalsupport@example.com',
+        title: undefined,
+        children: [{ type: RuleType.text, text: 'technicalsupport@example.com' }],
+      } as MarkdownToJSX.ASTNode,
+    ])
+  })
+
+    it('rejects angle autolinks containing tabs', () => {
     const state = createInlineState()
     const options: p.ParseOptions = {
       disableParsingRawHTML: true,

--- a/lib/src/parse.ts
+++ b/lib/src/parse.ts
@@ -4712,6 +4712,11 @@ function parseInline(s: string, p: number, e: number, state: MarkdownToJSX.State
       // Only skip when not near an @ (email detection needs alphanumeric chars)
       if (nextAtPos < 0 || nextAtPos - p > 64) {
         while (p < e) {
+          // Stop before entering the email detection window — the fast-skip must not
+          // jump past the start of an email's local-part (max 64 chars before @).
+          // Without this, an INLINE_SPECIAL char inside the local-part (e.g. 'h' in
+          // "technicalsupport@…") becomes the scan start, silently truncating the address.
+          if (nextAtPos >= 0 && nextAtPos - p <= 64) break
           var nc = s.charCodeAt(p)
           if (nc < $.CHAR_ASCII_BOUNDARY && !INLINE_SPECIAL[nc]) p++
           else break


### PR DESCRIPTION
Fixes #877

## What's wrong

The inline scanner uses a fast-skip loop to jump over plain text to the next `INLINE_SPECIAL` character. `INLINE_SPECIAL` includes `h`, `w`, and `f` because they are the opening characters of `http://`, `www.`, and `ftp://` URLs.

An outer guard disables the per-character email check when the `@` sign is more than 64 characters away (the RFC 5321 local-part limit). The guard works correctly at entry, but the fast-skip `while` loop has no matching exit boundary — once it starts it can advance `p` well past the start of the email's local-part, stopping only at the first `INLINE_SPECIAL` character *inside* the local-part.

**Concrete trace** for the reported input:

```
Please contact Support at 1-111-111-1111 or email technicalsupport@example.com …
^                                                  ^              ^
p=0                                                p=50           h at p=53    @ at p=66
```

1. At `p=0`: `nextAtPos - p = 66 > 64` → email check skipped.
2. `p++` → `p=1`; fast-skip enabled (65 > 64); loop runs forward.
3. Loop stops at `h` (p=53) — first `INLINE_SPECIAL` hit.
4. Email scan fires from `p=53` → matches `hnicalsupport@example.com`.
5. `tec` (p=50–52) was never considered, emitted as plain text.

The same bug triggers for any local-part that contains `h`, `w`, or `f` when the `@` is more than 64 characters from the start of the parsed context.

## Fix

Add one early-exit condition inside the fast-skip `while` loop — break before entering the 64-char email detection window, mirroring the boundary already on the outer guard:

```diff
       if (nextAtPos < 0 || nextAtPos - p > 64) {
         while (p < e) {
+          if (nextAtPos >= 0 && nextAtPos - p <= 64) break
           var nc = s.charCodeAt(p)
           if (nc < $.CHAR_ASCII_BOUNDARY && !INLINE_SPECIAL[nc]) p++
           else break
         }
       }
```

This is a one-line change with no effect on inputs that don't contain bare email addresses.

## Tests added (`lib/src/parse.spec.ts`)

1. **Regression — `h` in local-part, `@` far from start** — the exact input from issue #877.
2. **Regression — `w` and `f` in local-part, `@` far from start** — covers the other two `INLINE_SPECIAL` URL-prefix chars.
3. **Baseline — email at start of string** — confirms the non-fast-skip path still works.