### PR TITLE
fix: avoid quadratic-time parsing on inputs with many unterminated link openers (#874)

### DIFF
--- a/.changeset/swift-bears-clap.md
+++ b/.changeset/swift-bears-clap.md
@@ -2,4 +2,4 @@
 "markdown-to-jsx": patch
 ---
 
-fix: avoid slow parsing of pathological input with many unterminated link openers
+Markdown with many malformed link starts (e.g. repeated `[](`) now parses quickly instead of slowing to a crawl on large inputs.

--- a/.changeset/swift-bears-clap.md
+++ b/.changeset/swift-bears-clap.md
@@ -1,0 +1,5 @@
+---
+"markdown-to-jsx": patch
+---
+
+fix: avoid slow parsing of pathological input with many unterminated link openers

--- a/lib/src/parse.spec.ts
+++ b/lib/src/parse.spec.ts
@@ -295,18 +295,47 @@ describe('parseMarkdown', () => {
   })
 
   it('parses many unterminated inline-link openers in linear time (issue #874)', () => {
-    // Pre-fix, each `[](` retries the bare-URL scan to end-of-input, giving
-    // O(N^2) total work. With N=20000 (60KB) this took ~1s; N=32000 ~4s.
-    const N = 20000
-    const input = '[]('.repeat(N)
-    const start = performance.now()
-    const result = p.parser(input)
-    const elapsed = performance.now() - start
-    expect(elapsed).toBeLessThan(500)
+    // Pre-fix, each `[](` retried the bare-URL scan to end-of-input, giving
+    // O(N^2) total work (N=8000 ~260ms, N=32000 ~4s). Compare doubling-size
+    // runs and assert sub-quadratic scaling, which is robust to absolute
+    // machine speed.
+    function timeParse(N: number) {
+      const input = '[]('.repeat(N)
+      // One warmup to stabilize JIT.
+      p.parser(input)
+      const start = performance.now()
+      const result = p.parser(input)
+      return { ms: performance.now() - start, result, input }
+    }
+    const small = timeParse(8000)
+    const large = timeParse(16000)
+    // 2x input should be <3x time for linear behavior. Pre-fix this ratio was
+    // ~4x. Use 3x to absorb timing noise on small absolute durations.
+    expect(large.ms).toBeLessThan(small.ms * 3 + 50)
+    expect(large.result).toEqual([
+      {
+        type: RuleType.paragraph,
+        children: [{ type: RuleType.text, text: large.input }],
+      },
+    ])
+  })
+
+  it('does not let the failed-link cache reject a valid trailing link (issue #874 follow-up)', () => {
+    // `[](([](a)` — outer link fails because the bare URL walks to end without
+    // a balanced ')'. The cache must not block the inner `[](a)` from parsing.
+    const result = p.parser('[](([](a)')
     expect(result).toEqual([
       {
         type: RuleType.paragraph,
-        children: [{ type: RuleType.text, text: input }],
+        children: [
+          { type: RuleType.text, text: '[]((' },
+          {
+            type: RuleType.link,
+            target: 'a',
+            title: undefined,
+            children: [],
+          },
+        ],
       },
     ])
   })

--- a/lib/src/parse.spec.ts
+++ b/lib/src/parse.spec.ts
@@ -294,6 +294,23 @@ describe('parseMarkdown', () => {
     ])
   })
 
+  it('parses many unterminated inline-link openers in linear time (issue #874)', () => {
+    // Pre-fix, each `[](` retries the bare-URL scan to end-of-input, giving
+    // O(N^2) total work. With N=20000 (60KB) this took ~1s; N=32000 ~4s.
+    const N = 20000
+    const input = '[]('.repeat(N)
+    const start = performance.now()
+    const result = p.parser(input)
+    const elapsed = performance.now() - start
+    expect(elapsed).toBeLessThan(500)
+    expect(result).toEqual([
+      {
+        type: RuleType.paragraph,
+        children: [{ type: RuleType.text, text: input }],
+      },
+    ])
+  })
+
   it('parses mailto autolinks with label preserved', () => {
     const state = createInlineState()
     const options = { ...createDefaultOptions(), sanitizer: (x: string) => x }

--- a/lib/src/parse.ts
+++ b/lib/src/parse.ts
@@ -3733,8 +3733,9 @@ function scanLink(s: string, p: number, e: number, state: MarkdownToJSX.State, o
       }
     } else if (inlineOk) {
       // Bare URL - count parens. If a prior scan from <= i walked to
-      // end-of-input without examining any ')' at all, every later start sees
-      // the same ')'-free suffix and also fails — short-circuit (issue #874).
+      // end-of-input without examining any unescaped ')' (escaped `\)` is
+      // skipped by the backslash branch above), every later start sees the
+      // same `)`-free suffix and also fails — short-circuit (issue #874).
       // Caching on parenDepth alone would be unsound: a ')' seen at depth>0
       // from here may sit at depth 0 from a later start (e.g. `[](([](a)`).
       // Scoped per parseInline call so the source string can't change
@@ -3743,20 +3744,20 @@ function scanLink(s: string, p: number, e: number, state: MarkdownToJSX.State, o
         inlineOk = false
       } else {
         var parenDepth = 0
-        var sawCloseParen = false
+        var sawUnescapedCloseParen = false
         while (urlEnd < e) {
           var c2 = s.charCodeAt(urlEnd)
           if (c2 === $.CHAR_BACKSLASH && urlEnd + 1 < e) { urlEnd += 2; continue }
           if (c2 === $.CHAR_PAREN_OPEN) parenDepth++
           else if (c2 === $.CHAR_PAREN_CLOSE) {
-            sawCloseParen = true
+            sawUnescapedCloseParen = true
             if (parenDepth === 0) break
             parenDepth--
           }
           else if (c2 === $.CHAR_SPACE || c2 === $.CHAR_NEWLINE) break
           urlEnd++
         }
-        if (urlEnd >= e && !sawCloseParen && (state._inlineUrlFailFrom === undefined || i < state._inlineUrlFailFrom)) {
+        if (urlEnd >= e && !sawUnescapedCloseParen && (state._inlineUrlFailFrom === undefined || i < state._inlineUrlFailFrom)) {
           state._inlineUrlFailFrom = i
         }
         url = s.slice(i, urlEnd)

--- a/lib/src/parse.ts
+++ b/lib/src/parse.ts
@@ -3732,20 +3732,36 @@ function scanLink(s: string, p: number, e: number, state: MarkdownToJSX.State, o
         urlEnd++ // skip >
       }
     } else if (inlineOk) {
-      // Bare URL - count parens
-      var parenDepth = 0
-      while (urlEnd < e) {
-        var c2 = s.charCodeAt(urlEnd)
-        if (c2 === $.CHAR_BACKSLASH && urlEnd + 1 < e) { urlEnd += 2; continue }
-        if (c2 === $.CHAR_PAREN_OPEN) parenDepth++
-        else if (c2 === $.CHAR_PAREN_CLOSE) {
-          if (parenDepth === 0) break
-          parenDepth--
+      // Bare URL - count parens. If a prior scan from a position <= i on this
+      // same source already walked to end-of-input without finding a balanced
+      // ')' (no backslash escapes seen), the same is true for any later start,
+      // so we can short-circuit (issue #874).
+      if (state._inlineUrlFailSrc === s && state._inlineUrlFailFrom !== undefined && i >= state._inlineUrlFailFrom) {
+        inlineOk = false
+      } else {
+        var parenDepth = 0
+        var sawBackslash = false
+        while (urlEnd < e) {
+          var c2 = s.charCodeAt(urlEnd)
+          if (c2 === $.CHAR_BACKSLASH && urlEnd + 1 < e) { sawBackslash = true; urlEnd += 2; continue }
+          if (c2 === $.CHAR_PAREN_OPEN) parenDepth++
+          else if (c2 === $.CHAR_PAREN_CLOSE) {
+            if (parenDepth === 0) break
+            parenDepth--
+          }
+          else if (c2 === $.CHAR_SPACE || c2 === $.CHAR_NEWLINE) break
+          urlEnd++
         }
-        else if (c2 === $.CHAR_SPACE || c2 === $.CHAR_NEWLINE) break
-        urlEnd++
+        if (urlEnd >= e && !sawBackslash) {
+          if (state._inlineUrlFailSrc !== s) {
+            state._inlineUrlFailSrc = s
+            state._inlineUrlFailFrom = i
+          } else if (state._inlineUrlFailFrom === undefined || i < state._inlineUrlFailFrom) {
+            state._inlineUrlFailFrom = i
+          }
+        }
+        url = s.slice(i, urlEnd)
       }
-      url = s.slice(i, urlEnd)
     }
 
     if (inlineOk) {

--- a/lib/src/parse.ts
+++ b/lib/src/parse.ts
@@ -3732,28 +3732,31 @@ function scanLink(s: string, p: number, e: number, state: MarkdownToJSX.State, o
         urlEnd++ // skip >
       }
     } else if (inlineOk) {
-      // Bare URL - count parens. If a prior scan on this same string already
-      // reached end-of-input without finding a balanced ')' (no backslash
-      // escapes seen), every later start fails too — short-circuit (issue
-      // #874). Cache is scoped to the enclosing parseInline call so the source
-      // string can't change underneath us.
+      // Bare URL - count parens. If a prior scan from <= i walked to
+      // end-of-input without examining any ')' at all, every later start sees
+      // the same ')'-free suffix and also fails — short-circuit (issue #874).
+      // Caching on parenDepth alone would be unsound: a ')' seen at depth>0
+      // from here may sit at depth 0 from a later start (e.g. `[](([](a)`).
+      // Scoped per parseInline call so the source string can't change
+      // underneath us.
       if (state._inlineUrlFailFrom !== undefined && i >= state._inlineUrlFailFrom) {
         inlineOk = false
       } else {
         var parenDepth = 0
-        var sawBackslash = false
+        var sawCloseParen = false
         while (urlEnd < e) {
           var c2 = s.charCodeAt(urlEnd)
-          if (c2 === $.CHAR_BACKSLASH && urlEnd + 1 < e) { sawBackslash = true; urlEnd += 2; continue }
+          if (c2 === $.CHAR_BACKSLASH && urlEnd + 1 < e) { urlEnd += 2; continue }
           if (c2 === $.CHAR_PAREN_OPEN) parenDepth++
           else if (c2 === $.CHAR_PAREN_CLOSE) {
+            sawCloseParen = true
             if (parenDepth === 0) break
             parenDepth--
           }
           else if (c2 === $.CHAR_SPACE || c2 === $.CHAR_NEWLINE) break
           urlEnd++
         }
-        if (urlEnd >= e && !sawBackslash && (state._inlineUrlFailFrom === undefined || i < state._inlineUrlFailFrom)) {
+        if (urlEnd >= e && !sawCloseParen && (state._inlineUrlFailFrom === undefined || i < state._inlineUrlFailFrom)) {
           state._inlineUrlFailFrom = i
         }
         url = s.slice(i, urlEnd)

--- a/lib/src/parse.ts
+++ b/lib/src/parse.ts
@@ -3732,11 +3732,12 @@ function scanLink(s: string, p: number, e: number, state: MarkdownToJSX.State, o
         urlEnd++ // skip >
       }
     } else if (inlineOk) {
-      // Bare URL - count parens. If a prior scan from a position <= i on this
-      // same source already walked to end-of-input without finding a balanced
-      // ')' (no backslash escapes seen), the same is true for any later start,
-      // so we can short-circuit (issue #874).
-      if (state._inlineUrlFailSrc === s && state._inlineUrlFailFrom !== undefined && i >= state._inlineUrlFailFrom) {
+      // Bare URL - count parens. If a prior scan on this same string already
+      // reached end-of-input without finding a balanced ')' (no backslash
+      // escapes seen), every later start fails too — short-circuit (issue
+      // #874). Cache is scoped to the enclosing parseInline call so the source
+      // string can't change underneath us.
+      if (state._inlineUrlFailFrom !== undefined && i >= state._inlineUrlFailFrom) {
         inlineOk = false
       } else {
         var parenDepth = 0
@@ -3752,13 +3753,8 @@ function scanLink(s: string, p: number, e: number, state: MarkdownToJSX.State, o
           else if (c2 === $.CHAR_SPACE || c2 === $.CHAR_NEWLINE) break
           urlEnd++
         }
-        if (urlEnd >= e && !sawBackslash) {
-          if (state._inlineUrlFailSrc !== s) {
-            state._inlineUrlFailSrc = s
-            state._inlineUrlFailFrom = i
-          } else if (state._inlineUrlFailFrom === undefined || i < state._inlineUrlFailFrom) {
-            state._inlineUrlFailFrom = i
-          }
+        if (urlEnd >= e && !sawBackslash && (state._inlineUrlFailFrom === undefined || i < state._inlineUrlFailFrom)) {
+          state._inlineUrlFailFrom = i
         }
         url = s.slice(i, urlEnd)
       }
@@ -4402,6 +4398,11 @@ function parseInline(s: string, p: number, e: number, state: MarkdownToJSX.State
     return [{ type: RuleType.text, text: s.slice(p, e) }]
   }
 
+  // Scope scanLink's URL-scan failure cache to this call so positions can't
+  // bleed across different source strings (issue #874).
+  var savedUrlFailFrom = state._inlineUrlFailFrom
+  state._inlineUrlFailFrom = undefined
+
   // Use state directly to avoid object spread allocation
   const childState = state
 
@@ -4759,6 +4760,7 @@ function parseInline(s: string, p: number, e: number, state: MarkdownToJSX.State
     processEmphasis(nodes, delimStack, state, opts)
   }
 
+  state._inlineUrlFailFrom = savedUrlFailFrom
   _globalInlineDepth--
   return nodes
 }

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -92,9 +92,7 @@ declare namespace MarkdownToJSX {
     _htmlDepth?: number
     /** internal: set by collectReferenceDefinitions when input ends inside an unclosed fence */
     _endsInsideFence?: boolean
-    /** internal: source string for which `_inlineUrlFailFrom` is valid */
-    _inlineUrlFailSrc?: string
-    /** internal: smallest bare-URL start position known to fail by reaching end-of-input (issue #874) */
+    /** internal: smallest bare-URL start position known to fail by reaching end-of-input (issue #874); scoped per parseInline call */
     _inlineUrlFailFrom?: number
   }
 

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -92,6 +92,10 @@ declare namespace MarkdownToJSX {
     _htmlDepth?: number
     /** internal: set by collectReferenceDefinitions when input ends inside an unclosed fence */
     _endsInsideFence?: boolean
+    /** internal: source string for which `_inlineUrlFailFrom` is valid */
+    _inlineUrlFailSrc?: string
+    /** internal: smallest bare-URL start position known to fail by reaching end-of-input (issue #874) */
+    _inlineUrlFailFrom?: number
   }
 
   /**


### PR DESCRIPTION
Cache "bare URL scan reached end-of-input from position X" so repeated
malformed `[](` openers don't each re-scan the remainder. Disabled when a
backslash escape was seen in the scanned region to preserve correctness for
backslash-escaped parens in URLs.