### PR TITLE
fix(native): wrap bare text in tight list items with Text

### DIFF
--- a/lib/src/native.spec.tsx
+++ b/lib/src/native.spec.tsx
@@ -1333,3 +1333,68 @@ describe('regression #881 - trailing text after a nested HTML element', () => {
     ).toMatchInlineSnapshot(`"<View><Text>a</Text></View> tail"`)
   })
 })
+
+// A bare string as a direct child of a View crashes React Native with
+// "Text strings must be rendered within a <Text> component", so every
+// string in the tree must have a Text ancestor closer than any View
+// ancestor. Walk the tree tracking whichever of View/Text was seen last.
+function assertNoBareTextUnderView(
+  node: React.ReactNode,
+  nearestAncestorIsView = false
+): void {
+  if (node == null || typeof node === 'boolean') return
+  if (typeof node === 'string' || typeof node === 'number') {
+    if (nearestAncestorIsView) {
+      throw new Error(
+        `found bare text node "${node}" as a descendant of a View with no intervening Text`
+      )
+    }
+    return
+  }
+  if (Array.isArray(node)) {
+    node.forEach(child => assertNoBareTextUnderView(child, nearestAncestorIsView))
+    return
+  }
+  if (React.isValidElement(node)) {
+    const isView = isComponentType(node, View)
+    const isText = isComponentType(node, Text)
+    assertNoBareTextUnderView(
+      (node.props as any).children,
+      isView ? true : isText ? false : nearestAncestorIsView
+    )
+  }
+}
+
+describe('regression #884 - tight list items crash React Native with a bare text node', () => {
+  it('plain-text ordered list items are wrapped in Text', () => {
+    const result = compiler('1. First item\n2. Second item')
+    expect(() => assertNoBareTextUnderView(result)).not.toThrow()
+    expect(
+      serialize(result)
+    ).toMatchInlineSnapshot(
+      `"<View><View><Text>1. </Text><View><Text>First item</Text></View></View><View><Text>2. </Text><View><Text>Second item</Text></View></View></View>"`
+    )
+  })
+
+  it('plain-text unordered list items are wrapped in Text', () => {
+    const result = compiler('- First item\n- Second item')
+    expect(() => assertNoBareTextUnderView(result)).not.toThrow()
+  })
+
+  it('list items mixing plain text with bold/link content stay valid', () => {
+    const result = compiler(
+      '1. First item\n2. Second item with **bold text**\n3. Third item with a [link](https://example.com)'
+    )
+    expect(() => assertNoBareTextUnderView(result)).not.toThrow()
+  })
+
+  it('GFM task list item labels are wrapped in Text', () => {
+    const result = compiler('- [ ] todo item\n- [x] done item')
+    expect(() => assertNoBareTextUnderView(result)).not.toThrow()
+  })
+
+  it('nested list items are wrapped in Text', () => {
+    const result = compiler('- outer\n  - inner item')
+    expect(() => assertNoBareTextUnderView(result)).not.toThrow()
+  })
+})

--- a/lib/src/native.tsx
+++ b/lib/src/native.tsx
@@ -35,6 +35,28 @@ const TEXT_FORMAT_STYLES: Record<string, TextStyle> = {
 const mergeStyle = <T,>(d: T | undefined, u: T | undefined): T | T[] | undefined =>
   u ? (d ? [d, u] : u) : d
 
+// Tight list items render their inline content straight from `output()`,
+// which returns bare strings for plain-text runs (no intervening paragraph
+// wrapper the way loose items get). React Native throws "Text strings must
+// be rendered within a <Text> component" if such a string ends up as a
+// direct child of a View, so wrap any top-level string children in Text
+// before handing them to the list item's View wrapper.
+const wrapLooseStringsInText = (content: React.ReactNode): React.ReactNode => {
+  if (typeof content === 'string') {
+    return content ? React.createElement(Text, { key: 'text' }, content) : null
+  }
+  if (Array.isArray(content)) {
+    return content.map((child, i) =>
+      typeof child === 'string'
+        ? child
+          ? React.createElement(Text, { key: `text-${i}` }, child)
+          : null
+        : child
+    )
+  }
+  return content
+}
+
 /**
  * React context for sharing compiler options across Markdown components in React Native
  */
@@ -514,7 +536,11 @@ function render(
             'li',
             { key: i, style: liStyle },
             h(Text, { style: bulletStyle }, bullet + ' '),
-            h(View, { style: innerItemStyle }, output(item, state))
+            h(
+              View,
+              { style: innerItemStyle },
+              wrapLooseStringsInText(output(item, state))
+            )
           )
         })
       )


### PR DESCRIPTION
Closes #884. Tight list items render their inline content straight from `output()`, which returns a plain string for text runs (loose items get a paragraph wrapper first, tight ones don't). That string then lands as a direct child of the item's `View`, which RN rejects with "Text strings must be rendered within a `<Text>` component". Same code path handles task list labels and nested list items so they crash the same way.

Fix wraps any top-level bare strings coming out of `output(item, state)` in `Text` before they reach the `View`. Added tests covering plain tight lists, mixed bold/link content, task items, and nested lists — they throw without the fix and pass with it.