### PR TITLE
fix: render URLs containing non-BMP characters

### DIFF
--- a/.changeset/tidy-urls-smile.md
+++ b/.changeset/tidy-urls-smile.md
@@ -1,0 +1,5 @@
+---
+'markdown-to-jsx': patch
+---
+
+URLs containing emoji and other non-BMP Unicode characters now render without crashing.

--- a/lib/src/html.spec.ts
+++ b/lib/src/html.spec.ts
@@ -1106,6 +1106,14 @@ describe('html compiler', () => {
   })
 
   describe('URL reencoding after sanitization', () => {
+    it('should encode non-BMP characters in internationalized URLs', () => {
+      expect(
+        compiler('[Author post](https://例え.テスト/著者/𠮷田/投稿-🚀)')
+      ).toContain(
+        'href="https://%E4%BE%8B%E3%81%88.%E3%83%86%E3%82%B9%E3%83%88/%E8%91%97%E8%80%85/%F0%A0%AE%B7%E7%94%B0/%E6%8A%95%E7%A8%BF-%F0%9F%9A%80"'
+      )
+    })
+
     it('should reencode backslashes and backticks after sanitization', () => {
       // Create a URL that gets sanitized and contains backslashes/backticks
       const result = astToHTML(

--- a/lib/src/native.spec.tsx
+++ b/lib/src/native.spec.tsx
@@ -298,6 +298,21 @@ describe('link handling', () => {
     expect(typeof props.onPress).toBe('function')
   })
 
+  it('should encode non-BMP characters in URLs', () => {
+    const onLinkPress = mock((url: string) => {})
+    const result = compiler('[Author post](https://例え.テスト/著者/𠮷田/投稿-🚀)', {
+      onLinkPress,
+    })
+    const linkElement = findLinkElement(getFirstElement(result))
+
+    linkElement.props.onPress()
+
+    expect(onLinkPress).toHaveBeenCalledWith(
+      'https://%E4%BE%8B%E3%81%88.%E3%83%86%E3%82%B9%E3%83%88/%E8%91%97%E8%80%85/%F0%A0%AE%B7%E7%94%B0/%E6%8A%95%E7%A8%BF-%F0%9F%9A%80',
+      undefined
+    )
+  })
+
   it('should handle onLinkLongPress when provided', () => {
     const onLinkLongPress = mock((url: string) => {})
     const result = compiler('[Link](https://example.com)', { onLinkLongPress })

--- a/lib/src/react.spec.tsx
+++ b/lib/src/react.spec.tsx
@@ -1016,6 +1016,14 @@ describe('links', () => {
     )
   })
 
+  it('should encode non-BMP characters in internationalized URLs', () => {
+    render(compiler('[Author post](https://例え.テスト/著者/𠮷田/投稿-🚀)'))
+
+    expect(root.innerHTML).toBe(
+      '<a href="https://%E4%BE%8B%E3%81%88.%E3%83%86%E3%82%B9%E3%83%88/%E8%91%97%E8%80%85/%F0%A0%AE%B7%E7%94%B0/%E6%8A%95%E7%A8%BF-%F0%9F%9A%80">Author post</a>'
+    )
+  })
+
   it('should encode mixed backslashes and backticks in URLs', () => {
     render(compiler('[link](http://example.com/path\\with`mixed`\\chars)'))
 

--- a/lib/src/solid.spec.tsx
+++ b/lib/src/solid.spec.tsx
@@ -226,6 +226,16 @@ describe('links', () => {
     ).toContain('%')
   })
 
+  it('should encode non-BMP characters in URLs', () => {
+    expect(
+      JSON.stringify(
+        compiler('[Author post](https://例え.テスト/著者/𠮷田/投稿-🚀)')
+      )
+    ).toContain(
+      'https://%E4%BE%8B%E3%81%88.%E3%83%86%E3%82%B9%E3%83%88/%E8%91%97%E8%80%85/%F0%A0%AE%B7%E7%94%B0/%E6%8A%95%E7%A8%BF-%F0%9F%9A%80'
+    )
+  })
+
   it('should preserve existing percent-encoded sequences in URLs', () => {
     const str = JSON.stringify(
       compiler('[Link](https://example.com/path%20to%20file)')

--- a/lib/src/utils.spec.ts
+++ b/lib/src/utils.spec.ts
@@ -506,6 +506,29 @@ describe('sanitizer', () => {
   })
 })
 
+describe('encodeUrlTarget', () => {
+  it('should encode internationalized URLs containing non-BMP characters', () => {
+    expect(u.encodeUrlTarget('https://例え.テスト/著者/𠮷田/投稿-🚀')).toBe(
+      'https://%E4%BE%8B%E3%81%88.%E3%83%86%E3%82%B9%E3%83%88/%E8%91%97%E8%80%85/%F0%A0%AE%B7%E7%94%B0/%E6%8A%95%E7%A8%BF-%F0%9F%9A%80'
+    )
+    expect(u.encodeUrlTarget('https://example.com/@𝒜stroWriter')).toBe(
+      'https://example.com/@%F0%9D%92%9CstroWriter'
+    )
+    expect(u.encodeUrlTarget('https://example.com/ブログ/launch-🚀')).toBe(
+      'https://example.com/%E3%83%96%E3%83%AD%E3%82%B0/launch-%F0%9F%9A%80'
+    )
+  })
+
+  it('should preserve lone surrogates without throwing', () => {
+    expect(u.encodeUrlTarget('https://example.com/\uD800')).toBe(
+      'https://example.com/\uD800'
+    )
+    expect(u.encodeUrlTarget('https://example.com/\uDC00')).toBe(
+      'https://example.com/\uDC00'
+    )
+  })
+})
+
 describe('slugify', () => {
   it('should convert text to URL-safe slugs', () => {
     expect(u.slugify('Hello World')).toBe('hello-world')

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -918,6 +918,18 @@ export function encodeUrlTarget(target: string): string {
         continue
       }
     }
+    if (code >= 0xd800 && code <= 0xdfff) {
+      if (code <= 0xdbff && i + 1 < target.length) {
+        var nextCode = target.charCodeAt(i + 1)
+        if (nextCode >= 0xdc00 && nextCode <= 0xdfff) {
+          result += encodeURI(target[i] + target[i + 1])
+          i++
+          continue
+        }
+      }
+      result += target[i]
+      continue
+    }
     result += encodeURI(target[i])
   }
   return result

--- a/lib/src/vue.spec.tsx
+++ b/lib/src/vue.spec.tsx
@@ -959,6 +959,15 @@ describe('URL encoding edge cases', () => {
     expect(href as string).toContain('%')
   })
 
+  it('should encode non-BMP characters in internationalized URLs', () => {
+    const result = compiler(
+      '[Author post](https://例え.テスト/著者/𠮷田/投稿-🚀)'
+    )
+    expect(getProp(result, 'href')).toBe(
+      'https://%E4%BE%8B%E3%81%88.%E3%83%86%E3%82%B9%E3%83%88/%E8%91%97%E8%80%85/%F0%A0%AE%B7%E7%94%B0/%E6%8A%95%E7%A8%BF-%F0%9F%9A%80'
+    )
+  })
+
   it('should handle URLs with existing percent encoding', () => {
     const result = compiler('[Link](http://example.com/path%5Cfile)')
     const href = getProp(result, 'href')


### PR DESCRIPTION
## Problem

Internationalized URLs containing emoji or other non-BMP Unicode characters can crash rendering with `URIError: URI malformed`.

Examples include:

```md
[Author post](https://例え.テスト/著者/𠮷田/投稿-🚀)
[Writer profile](https://example.com/@𝒜stroWriter)
[Launch notes](https://example.com/ブログ/launch-🚀)
```

URL encoding was processing each UTF-16 code unit separately, causing half of a surrogate pair to be passed to `encodeURI`.

## Fix

- Encode valid surrogate pairs together as complete Unicode characters.
- Preserve isolated surrogate code units instead of throwing on malformed input.
- Preserve existing percent-encoded sequences and encoding behavior for other characters.

This does not change how Markdown links are parsed or introduce new IDN normalization. It prevents valid Unicode URLs from crashing when producing output.

## Test plan

- [x] Added focused coverage for internationalized domains and paths, stylized characters, `𠮷`, and emoji.
- [x] Added coverage for isolated high and low surrogates.
- [x] Verified a representative internationalized URL in React, React Native, Solid, Vue, and HTML output.
- [x] All 2,286 tests pass.
- [x] Library and site build successfully.